### PR TITLE
Add handbook redirect

### DIFF
--- a/src/metalsmith/settings/_redirects
+++ b/src/metalsmith/settings/_redirects
@@ -15,6 +15,7 @@ https://www.effectivealtruism.com/the-movement https://www.effectivealtruism.org
 https://www.effectivealtruism.com https://www.effectivealtruism.org 301
 # http://www.effectivealtruism.com/* https://www.effectivealtruism.org/:splat 301
 https://www.effectivealtruism.com/* https://www.effectivealtruism.org/:splat 301!
+/handbook https://forum.effectivealtruism.org/handbook 301!
 /people /community-profiles 301
 /ideas /articles 301
 /ideas/* /articles/:splat 301


### PR DESCRIPTION
Aaron requested that effectivelatruism.org/handbook redirect to the Forum post. I'm running into an issue building locally that's preventing me from testing it there, but this seems straightforward enough that I don't see much room for surprises, and also it's low-risk to verify in production.